### PR TITLE
Don't override parsed values with other values

### DIFF
--- a/src/ttn_client/client.py
+++ b/src/ttn_client/client.py
@@ -108,6 +108,9 @@ class TTNClient:  # pylint: disable=too-few-public-methods
                 if ttn_output == {}:
                     continue
 
-                ttn_values[device_id] = ttn_output
+                if device_id in ttn_values:
+                    ttn_values[device_id] |= ttn_output
+                else:
+                    ttn_values[device_id] = ttn_output
 
         return ttn_values

--- a/src/ttn_client/client.py
+++ b/src/ttn_client/client.py
@@ -103,6 +103,11 @@ class TTNClient:  # pylint: disable=too-few-public-methods
                 # Get device_id and uplink_message from measurement
                 device_id = application_up["end_device_ids"]["device_id"]
 
-                ttn_values[device_id] = ttn_parse(application_up)
+                ttn_output = ttn_parse(application_up)
+
+                if ttn_output == {}:
+                    continue
+
+                ttn_values[device_id] = ttn_output
 
         return ttn_values

--- a/src/ttn_client/client.py
+++ b/src/ttn_client/client.py
@@ -108,6 +108,8 @@ class TTNClient:  # pylint: disable=too-few-public-methods
                 if ttn_output == {}:
                     continue
 
+                _LOGGER.debug("TTN parsed values: %s", ttn_output)
+
                 if device_id in ttn_values:
                     ttn_values[device_id] |= ttn_output
                 else:


### PR DESCRIPTION
If processing multiple packets only the last packet gets kept. This ensures that we process all of the packets.

According to [PEP0584](https://peps.python.org/pep-0584/#specification) the newset value should be used if the value is set multiple times.