### PR TITLE
Fix SenseCAP parser to handle nested list format from T1000 devices

### DIFF
--- a/src/ttn_client/parsers/sensecap.py
+++ b/src/ttn_client/parsers/sensecap.py
@@ -40,12 +40,22 @@ def sensecap_parser(uplink_data: dict) -> dict[str, TTNBaseValue]:
                 # Parse messages
                 messages = decoded_payload["messages"]
                 for value_item in messages:
-                    __sensecap_parse_msg(
-                        ttn_values,
-                        device_id,
-                        uplink_data,
-                        value_item,
-                    )
+                    # Handle nested list (each message can be a list of measurements)
+                    if isinstance(value_item, list):
+                        for measurement in value_item:
+                            __sensecap_parse_msg(
+                                ttn_values,
+                                device_id,
+                                uplink_data,
+                                measurement,
+                            )
+                    else:
+                        __sensecap_parse_msg(
+                            ttn_values,
+                            device_id,
+                            uplink_data,
+                            value_item,
+                        )
     return ttn_values
 
 

--- a/tests/parsers/conftest.py
+++ b/tests/parsers/conftest.py
@@ -26,3 +26,8 @@ def default_no_decoded_payload(request):
 @pytest.fixture
 def sensecap_valid(request):
     return json_config(request, "sensecap_valid.json")
+
+
+@pytest.fixture
+def sensecap_t1000_nested(request):
+    return json_config(request, "sensecap_t1000_nested.json")

--- a/tests/parsers/test_data/sensecap_t1000_nested.json
+++ b/tests/parsers/test_data/sensecap_t1000_nested.json
@@ -1,0 +1,135 @@
+{
+  "name": "as.up.data.forward",
+  "time": "2025-12-15T23:38:51.261316239Z",
+  "identifiers": [
+    {
+      "device_ids": {
+        "device_id": "test-t1000-device",
+        "application_ids": {
+          "application_id": "test-app"
+        },
+        "dev_eui": "0000000000000001",
+        "dev_addr": "00000001"
+      }
+    }
+  ],
+  "data": {
+    "@type": "type.googleapis.com/ttn.lorawan.v3.ApplicationUp",
+    "end_device_ids": {
+      "device_id": "test-t1000-device",
+      "application_ids": {
+        "application_id": "test-app"
+      },
+      "dev_eui": "0000000000000001",
+      "dev_addr": "00000001"
+    },
+    "correlation_ids": [
+      "gs:uplink:01TEST123456"
+    ],
+    "received_at": "2025-12-15T23:38:51.261316239Z",
+    "uplink_message": {
+      "f_port": 5,
+      "f_cnt": 34,
+      "frm_payload": "dGVzdHBheWxvYWRkYXRhZm9ydDEwMDB0ZXN0aW5ncHVycG9zZXM=",
+      "decoded_payload": {
+        "err": 0,
+        "messages": [
+          [
+            {
+              "measurementId": "4200",
+              "measurementValue": [],
+              "motionId": 0,
+              "timestamp": 1765841925000,
+              "type": "Event Status"
+            },
+            {
+              "measurementId": "5001",
+              "measurementValue": [
+                {
+                  "mac": "AA:BB:CC:DD:EE:01",
+                  "rssi": "-68"
+                },
+                {
+                  "mac": "AA:BB:CC:DD:EE:02",
+                  "rssi": "-91"
+                },
+                {
+                  "mac": "AA:BB:CC:DD:EE:03",
+                  "rssi": "-82"
+                },
+                {
+                  "mac": "AA:BB:CC:DD:EE:04",
+                  "rssi": "-83"
+                }
+              ],
+              "motionId": 0,
+              "timestamp": 1765841925000,
+              "type": "Wi-Fi Scan"
+            },
+            {
+              "measurementId": "3000",
+              "measurementValue": 88,
+              "motionId": 0,
+              "timestamp": 1765841925000,
+              "type": "Battery"
+            }
+          ]
+        ],
+        "payload": "74657374706179546f61646461746166f0727431303030746573",
+        "valid": true
+      },
+      "rx_metadata": [
+        {
+          "gateway_ids": {
+            "gateway_id": "test-gateway",
+            "eui": "0000000000000002"
+          },
+          "time": "2025-12-15T23:38:50.912254095Z",
+          "timestamp": 1258723744,
+          "rssi": -51,
+          "channel_rssi": -51,
+          "snr": 15.25,
+          "received_at": "2025-12-15T23:38:51.036053659Z"
+        }
+      ],
+      "settings": {
+        "data_rate": {
+          "lora": {
+            "bandwidth": 125000,
+            "spreading_factor": 7,
+            "coding_rate": "4/5"
+          }
+        },
+        "frequency": "867900000",
+        "timestamp": 1258723744,
+        "time": "2025-12-15T23:38:50.912254095Z"
+      },
+      "received_at": "2025-12-15T23:38:51.055388653Z",
+      "consumed_airtime": "0.102656s",
+      "version_ids": {
+        "brand_id": "sensecap",
+        "model_id": "sensecapt1000-tracker-ab",
+        "hardware_version": "1.0",
+        "firmware_version": "1.0",
+        "band_id": "EU_863_870"
+      },
+      "network_ids": {
+        "net_id": "000013",
+        "ns_id": "EC656E0000000181",
+        "tenant_id": "ttn",
+        "cluster_id": "eu1",
+        "cluster_address": "eu1.cloud.thethings.network"
+      }
+    }
+  },
+  "correlation_ids": [
+    "gs:uplink:01TEST123456"
+  ],
+  "origin": "test.eu-west-1.compute.internal",
+  "visibility": {
+    "rights": [
+      "RIGHT_APPLICATION_TRAFFIC_READ"
+    ]
+  },
+  "unique_id": "01TEST123456UNIQUE"
+}

--- a/tests/parsers/test_sensecap.py
+++ b/tests/parsers/test_sensecap.py
@@ -83,3 +83,84 @@ def test_sensecap_no_messages(sensecap_valid):
     del uplink_data["uplink_message"]["decoded_payload"]["messages"]
     ttn_values = ttn_parse(uplink_data)
     assert len(ttn_values) == 2
+
+
+def test_sensecap_t1000_nested_valid(sensecap_t1000_nested):
+    """Test valid T1000 msg with nested list structure."""
+    uplink_data = sensecap_t1000_nested["data"]
+    ttn_values = ttn_parse(uplink_data)
+
+    # Test that basic fields are present
+    assert "err" in ttn_values
+    assert "payload" in ttn_values
+
+    # Test err value
+    sensor_value = ttn_values["err"]
+    assert isinstance(sensor_value, TTNSensorValue)
+    assert sensor_value.value == 0
+
+    # Test payload value
+    sensor_value = ttn_values["payload"]
+    assert isinstance(sensor_value, TTNSensorValue)
+    assert isinstance(sensor_value.value, str)
+
+    # Test Wi-Fi Scan measurement (measurementId 5001)
+    field_id = "Wi-Fi_Scan_5001"
+    assert field_id in ttn_values
+    sensor_value = ttn_values[field_id]
+    assert isinstance(sensor_value, TTNSensorValue)
+    assert isinstance(sensor_value.value, list)
+    assert len(sensor_value.value) == 4
+    # Verify Wi-Fi scan data structure
+    assert sensor_value.value[0]["mac"] == "AA:BB:CC:DD:EE:01"
+    assert sensor_value.value[0]["rssi"] == "-68"
+
+    # Test Battery measurement (measurementId 3000)
+    field_id = "Battery_3000"
+    assert field_id in ttn_values
+    sensor_value = ttn_values[field_id]
+    assert isinstance(sensor_value, TTNSensorValue)
+    assert sensor_value.value == 88
+
+    # Test device metadata
+    assert sensor_value.device_id == "test-t1000-device"
+
+
+def test_sensecap_t1000_nested_backward_compat(sensecap_valid):
+    """Test that flat array format (S2120) still works after fix."""
+    uplink_data = sensecap_valid["data"]
+    ttn_values = ttn_parse(uplink_data)
+
+    # Verify that original flat format tests still pass
+    assert "Air_Temperature_4097" in ttn_values
+    assert "Air_Humidity_4098" in ttn_values
+    assert "battery" in ttn_values
+
+    # Verify values are correct
+    assert ttn_values["Air_Temperature_4097"].value == 13.3
+    assert ttn_values["Air_Humidity_4098"].value == 77
+    assert ttn_values["battery"].value == 100
+
+
+def test_sensecap_t1000_mixed_format(sensecap_t1000_nested):
+    """Test mixed format with both nested and flat items in messages array."""
+    uplink_data = sensecap_t1000_nested["data"]
+
+    # Modify to have mixed format: first item is nested, second is flat
+    decoded_payload = uplink_data["uplink_message"]["decoded_payload"]
+    flat_item = {
+        "measurementId": "4097",
+        "measurementValue": 25.5,
+        "type": "Air Temperature"
+    }
+    decoded_payload["messages"].append(flat_item)
+
+    ttn_values = ttn_parse(uplink_data)
+
+    # Verify nested items are parsed
+    assert "Wi-Fi_Scan_5001" in ttn_values
+    assert "Battery_3000" in ttn_values
+
+    # Verify flat item is also parsed
+    assert "Air_Temperature_4097" in ttn_values
+    assert ttn_values["Air_Temperature_4097"].value == 25.5


### PR DESCRIPTION
## Summary

Fixes parsing errors for SenseCAP T1000 tracker devices that send data with nested lists in the messages array.

### Problem

The SenseCAP T1000 tracker sends data with a nested list structure:
```json
{
  "decoded_payload": {
    "messages": [
      [
        {"measurementId": "4200", "measurementValue": [], "type": "Event Status"},
        {"measurementId": "5001", "measurementValue": [...], "type": "Wi-Fi Scan"},
        {"measurementId": "3000", "measurementValue": 88, "type": "Battery"}
      ]
    ]
  }
}
```

The parser expected a flat array format (`messages: [{...}, {...}]`) used by other SenseCAP devices like S2120, resulting in warnings:
```
Message for device {device_id} ignored (type <class 'list'>)
```

### Solution

Modified the `sensecap_parser` function to handle both nested and flat array structures by:
- Adding an `isinstance(value_item, list)` check to detect nested lists
- Iterating through nested measurements when detected
- Maintaining backward compatibility with existing flat array format

### Changes

- **Modified** `src/ttn_client/parsers/sensecap.py` - Added nested list handling (lines 43-58)
- **Added** `tests/parsers/test_data/sensecap_t1000_nested.json` - Test data for T1000 format
- **Modified** `tests/parsers/conftest.py` - Added fixture for T1000 test data
- **Modified** `tests/parsers/test_sensecap.py` - Added comprehensive tests:
  - `test_sensecap_t1000_nested_valid` - Tests nested list parsing
  - `test_sensecap_t1000_nested_backward_compat` - Verifies S2120 compatibility
  - `test_sensecap_t1000_mixed_format` - Tests mixed nested/flat formats

## Test Results

All 15 tests pass, including:
- ✅ All existing S2120 tests (backward compatibility confirmed)
- ✅ New T1000 nested list tests
- ✅ Mixed format handling

```bash
pytest tests/parsers/test_sensecap.py -v
# 7 passed
pytest tests/ -v
# 15 passed
```

## Devices Affected

- **T1000 tracker**: Now works correctly with nested list format
- **S2120 and others**: Continue to work with flat array format (backward compatible)

## Related Issues

This fix enables proper parsing of:
- Wi-Fi Scan measurements (measurementId 5001)
- Event Status measurements (measurementId 4200)
- Battery measurements (measurementId 3000)
- All other measurement types from T1000 devices