### PR TITLE
feat: add TTNSensorAttribute for _sensor_attr payload annotations

### DIFF
--- a/src/ttn_client/parsers/default.py
+++ b/src/ttn_client/parsers/default.py
@@ -3,12 +3,15 @@
 import logging
 from ..values import (
     TTNBaseValue,
-    TTNDeviceTrackerValue,
     TTNBinarySensorValue,
+    TTNDeviceTrackerValue,
+    TTNSensorAttribute,
     TTNSensorValue,
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+_SENSOR_ATTR_KEY = "_sensor_attr"
 
 
 def default_parser(uplink_data: dict) -> dict[str, TTNBaseValue]:
@@ -46,6 +49,17 @@ def __default_parse_field(
         if "latitude" in new_value and "longitude" in new_value:
             # GPS
             new_ttn_value = TTNDeviceTrackerValue(application_up, field_id, new_value)
+        elif field_id == _SENSOR_ATTR_KEY:
+            # _sensor_attr: { BatV: { unit: "V", device_class: "voltage" } }
+            for sensor_field, attr_dict in new_value.items():
+                if not isinstance(attr_dict, dict):
+                    continue
+                for attr_key, attr_value in attr_dict.items():
+                    flat_key = f"{_SENSOR_ATTR_KEY}_{sensor_field}_{attr_key}"
+                    ttn_values[flat_key] = TTNSensorAttribute(
+                        application_up, flat_key, str(attr_value)
+                    )
+            return
         else:
             # Other - such as acceleration -> split in multiple ttn_values
             for key, value_item in new_value.items():

--- a/src/ttn_client/values/__init__.py
+++ b/src/ttn_client/values/__init__.py
@@ -1,6 +1,7 @@
 """Exports public classes."""
 
+from .attribute import TTNSensorAttribute  # noqa: F401
 from .base import TTNBaseValue  # noqa: F401
-from .sensor import TTNSensorValue  # noqa: F401
 from .binary_sensor import TTNBinarySensorValue  # noqa: F401
 from .device_tracker import TTNDeviceTrackerValue  # noqa: F401
+from .sensor import TTNSensorValue  # noqa: F401

--- a/src/ttn_client/values/attribute.py
+++ b/src/ttn_client/values/attribute.py
@@ -1,0 +1,25 @@
+"""Sensor attribute value for The Things Network client."""
+
+from .base import TTNBaseValue
+
+
+class TTNSensorAttribute(TTNBaseValue):
+    """Holds a named attribute for a sensor field.
+
+    TTN payload decoders can annotate sensor fields with arbitrary
+    key-value pairs by returning a _sensor_attr object in the
+    decoded payload.
+
+    The attribute key names are defined by the decoder author and
+    are not interpreted by ttn_client. Consumers (e.g. a Home
+    Assistant integration) define the mapping from attribute names
+    to their platform-specific concepts.
+    """
+
+    @property
+    def value(self) -> str:
+        """Return the attribute value."""
+        return self._value
+
+    def __repr__(self) -> str:
+        return f"TTN_Attr({self._value})"

--- a/tests/parsers/conftest.py
+++ b/tests/parsers/conftest.py
@@ -9,7 +9,7 @@ import pytest
 def json_config(request, test_file):
     file = pathlib.Path(request.node.fspath.strpath)
     config = file.parent.joinpath("test_data", test_file)
-    with config.open() as fp:
+    with config.open(encoding="utf-8") as fp:
         return json.load(fp)
 
 
@@ -21,6 +21,11 @@ def default_valid(request):
 @pytest.fixture
 def default_no_decoded_payload(request):
     return json_config(request, "default_no_decoded_payload.json")
+
+
+@pytest.fixture
+def default_sensor_attr(request):
+    return json_config(request, "default_sensor_attr.json")
 
 
 @pytest.fixture

--- a/tests/parsers/test_data/default_sensor_attr.json
+++ b/tests/parsers/test_data/default_sensor_attr.json
@@ -1,0 +1,57 @@
+{
+    "name": "as.up.data.forward",
+    "time": "2024-07-06T09:19:21.385361320Z",
+    "identifiers": [
+      {
+        "device_ids": {
+          "device_id": "sensor-01",
+          "application_ids": {
+            "application_id": "home-assistant-casa"
+          }
+        }
+      }
+    ],
+    "data": {
+      "@type": "type.googleapis.com/ttn.lorawan.v3.ApplicationUp",
+      "end_device_ids": {
+        "device_id": "sensor-01",
+        "application_ids": {
+          "application_id": "home-assistant-casa"
+        }
+      },
+      "received_at": "2024-07-06T09:19:21.381960868Z",
+      "uplink_message": {
+        "f_port": 1,
+        "decoded_payload": {
+          "BatV": 3.016,
+          "TempC_SHT": 24.6,
+          "boolean_1": true,
+          "_sensor_attr": {
+            "BatV": {
+              "unit": "V",
+              "device_class": "voltage",
+              "state_class": "measurement",
+              "entity_category": "diagnostic"
+            },
+            "TempC_SHT": {
+              "unit": "°C",
+              "device_class": "temperature"
+            },
+            "invalid_entry": "not_a_dict"
+          }
+        },
+        "rx_metadata": [],
+        "settings": {
+          "data_rate": {
+            "lora": {
+              "bandwidth": 125000,
+              "spreading_factor": 7,
+              "coding_rate": "4/5"
+            }
+          },
+          "frequency": "868100000"
+        },
+        "received_at": "2024-07-06T09:19:21.175051417Z"
+      }
+    }
+  }

--- a/tests/parsers/test_default.py
+++ b/tests/parsers/test_default.py
@@ -4,10 +4,11 @@ import datetime
 import pytest
 
 from ttn_client import (
-    TTNSensorValue,
     TTNBaseValue,
     TTNBinarySensorValue,
     TTNDeviceTrackerValue,
+    TTNSensorAttribute,
+    TTNSensorValue,
 )
 from ttn_client.parsers import ttn_parse
 
@@ -107,6 +108,67 @@ def test_default_none_value(default_valid):
     uplink_with_none_value["uplink_message"]["decoded_payload"]["digital_in_1"] = None
     ttn_values_with_none = ttn_parse(uplink_with_none_value)
     assert len(ttn_values_with_none) == len(ttn_values) - 1
+
+
+def test_sensor_attr_parsed_as_attribute(default_sensor_attr):
+    """Test _sensor_attr fields are parsed as TTNSensorAttribute."""
+    ttn_values = ttn_parse(default_sensor_attr["data"])
+
+    # BatV attributes
+    assert isinstance(ttn_values["_sensor_attr_BatV_unit"], TTNSensorAttribute)
+    assert ttn_values["_sensor_attr_BatV_unit"].value == "V"
+    assert ttn_values["_sensor_attr_BatV_device_class"].value == "voltage"
+    assert ttn_values["_sensor_attr_BatV_state_class"].value == "measurement"
+    assert ttn_values["_sensor_attr_BatV_entity_category"].value == "diagnostic"
+
+    # TempC_SHT attributes
+    assert isinstance(ttn_values["_sensor_attr_TempC_SHT_unit"], TTNSensorAttribute)
+    assert ttn_values["_sensor_attr_TempC_SHT_unit"].value == "°C"
+    assert ttn_values["_sensor_attr_TempC_SHT_device_class"].value == "temperature"
+
+    # repr
+    assert repr(ttn_values["_sensor_attr_BatV_unit"]) == "TTN_Attr(V)"
+
+
+def test_sensor_attr_flat_keys(default_sensor_attr):
+    """Test all expected flat keys are present."""
+    ttn_values = ttn_parse(default_sensor_attr["data"])
+
+    expected_attr_keys = {
+        "_sensor_attr_BatV_unit",
+        "_sensor_attr_BatV_device_class",
+        "_sensor_attr_BatV_state_class",
+        "_sensor_attr_BatV_entity_category",
+        "_sensor_attr_TempC_SHT_unit",
+        "_sensor_attr_TempC_SHT_device_class",
+    }
+    actual_attr_keys = {
+        k for k, v in ttn_values.items() if isinstance(v, TTNSensorAttribute)
+    }
+    assert actual_attr_keys == expected_attr_keys
+
+
+def test_sensor_attr_non_dict_skipped(default_sensor_attr):
+    """Test non-dict entries in _sensor_attr are skipped."""
+    ttn_values = ttn_parse(default_sensor_attr["data"])
+
+    # "invalid_entry": "not_a_dict" should be skipped
+    invalid_keys = [k for k in ttn_values if "invalid_entry" in k]
+    assert invalid_keys == []
+
+
+def test_sensor_attr_normal_values_unchanged(default_sensor_attr):
+    """Test normal sensor values are not affected by _sensor_attr."""
+    ttn_values = ttn_parse(default_sensor_attr["data"])
+
+    # Normal sensor values remain TTNSensorValue
+    assert isinstance(ttn_values["BatV"], TTNSensorValue)
+    assert ttn_values["BatV"].value == 3.016
+    assert isinstance(ttn_values["TempC_SHT"], TTNSensorValue)
+    assert ttn_values["TempC_SHT"].value == 24.6
+
+    # Boolean still works
+    assert isinstance(ttn_values["boolean_1"], TTNBinarySensorValue)
 
 
 def test_default_unexpected_value(default_valid):


### PR DESCRIPTION
## Summary

Introduce `TTNSensorAttribute` as a dedicated value type so consumers can distinguish decoder-provided field annotations from actual sensor readings. Previously, `_sensor_attr` nested objects were flattened to `TTNSensorValue` entries, making it impossible to tell metadata apart from measurements.

## Changes

- New `TTNSensorAttribute(TTNBaseValue)` in `values/attribute.py`
- Default parser recognizes `_sensor_attr` and creates `TTNSensorAttribute` instances instead of recursively flattening to `TTNSensorValue`
- Non-dict entries in `_sensor_attr` are silently skipped
- Fix `conftest.py` to use explicit UTF-8 encoding for test data (Windows compatibility)
- 4 new test cases for `_sensor_attr` parsing

## Backward compatibility

- Fully backward compatible — no breaking changes
- Decoders without `_sensor_attr` work unchanged
- Existing consumers using `TTNSensorValue` are not affected

## Example

Decoder output:
```javascript
_sensor_attr: {
    BatV: { unit: "V", device_class: "voltage", state_class: "measurement" }
}
```

Parsed as:
```
_sensor_attr_BatV_unit         = TTNSensorAttribute("V")
_sensor_attr_BatV_device_class = TTNSensorAttribute("voltage")
_sensor_attr_BatV_state_class  = TTNSensorAttribute("measurement")
```

Consumers can identify annotations via `isinstance(value, TTNSensorAttribute)` and skip them when creating sensor entities.

## Motivation

See also: https://github.com/home-assistant/core/issues/159628 — this change enables a corresponding HA integration update that applies decoder-provided metadata (`unit`, `device_class`, `state_class`, `entity_category`) directly to sensor entities.

## Open design

`TTNSensorAttribute` is intentionally **not tied to Home Assistant**. The attribute key names are defined by the decoder author and are not interpreted by `ttn_client` — it simply provides the typed container. Any consumer can use `isinstance(value, TTNSensorAttribute)` to extract metadata and map it to platform-specific concepts, for example:

- **Home Assistant** — `device_class`, `unit_of_measurement`, `state_class`
- **Grafana / InfluxDB** — measurement names, field tags, units
- **Custom dashboards** — display formatting, chart configuration
